### PR TITLE
Set up staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ MONGO_ROOT_PASSWORD ## password for your mongo container ##
 MONGO_APP_USERNAME ## app username to connect to the database ##
 MONGO_APP_PASSWORD ## app password to connect to the database ##
 MONGO_DATABASE ## database name ##
-DATABASE_URI ## should look like this without const names : mongodb://MONGO_APP_USERNAME:MONGO_APP_PASSWORD@todoapp-mongodb-container:27017/MONGO_DATABASE?authSource=MONGO_DATABASE ##
+DATABASE_URI_DEVELOPMENT ## should look like this without const names : mongodb://MONGO_APP_USERNAME:MONGO_APP_PASSWORD@todoapp-mongodb-container:27017/MONGO_DATABASE?authSource=MONGO_DATABASE ##
+DATABASE_URI_STAGING ## mongodb+srv://<USER>:<PASSWORD>@<CLUSTERURL>/<DATABASE>?retryWrites=true&w=majority&appName=<CLUSTERNAME> ##
+DATABASE_URI_PRODUCTION ## mongodb+srv://<USER>:<PASSWORD>@<CLUSTERURL>/<DATABASE>?retryWrites=true&w=majority&appName=<CLUSTERNAME> ##
 ```
 
 To run the project :
@@ -18,6 +20,15 @@ docker compose up
 ```
 
 Go inside todoapp-container to start nextjs :
+
+To build the project locally with staging or production environment use :
+
+```
+npm run build:staging
+npm run build:production
+```
+
+To deploy in the cloud you need to set up the ENV_TARGET environment variable. ("staging" or "production")
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,11 +3,21 @@ declare global {
   var mongoose: any; // This must be a `var` and not a `let / const`
 }
 
-const DATABASE_URI = process.env.DATABASE_URI!;
+const DATABASE_URIS = {
+  development: process.env.DATABASE_URI_DEVELOPMENT!,
+  staging: process.env.DATABASE_URI_STAGING!,
+  production: process.env.DATABASE_URI_PRODUCTION!,
+};
+
+const ENV_TARGET = process.env.ENV_TARGET! as
+  | "development"
+  | "staging"
+  | "production";
+const DATABASE_URI = DATABASE_URIS[ENV_TARGET];
 
 if (!DATABASE_URI) {
   throw new Error(
-    "Please define the MONGODB_URI environment variable inside .env.local"
+    "Please define the DATABASE_URI_DEVELOPMENT, DATABASE_URI_STAGING and DATABASE_URI_PRODUCTION environment variables inside .env"
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "ENV_TARGET=development next dev",
+    "build:staging": "ENV_TARGET=staging next build",
+    "build:production": "ENV_TARGET=production next build",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
Use ENV_TARGET to build with staging or production DB. 
Add build:staging and build:production npm scripts.